### PR TITLE
create proper placeholders for bs oauth token in vcr

### DIFF
--- a/lib/bookingsync_application/spec_helper.rb
+++ b/lib/bookingsync_application/spec_helper.rb
@@ -12,10 +12,8 @@ VCR.configure do |config|
   config.cassette_library_dir = 'spec/fixtures/cassettes'
   config.hook_into :webmock
   config.configure_rspec_metadata!
-  config.filter_sensitive_data('Bearer <OAUTH_TOKEN>') do |interaction|
-    if interaction.request.headers['Authorization']
-      interaction.request.headers['Authorization'].first
-    end
+  config.filter_sensitive_data('BOOKINGSYNC_OAUTH_ACCESS_TOKEN') do
+    ENV['BOOKINGSYNC_OAUTH_ACCESS_TOKEN']
   end
   config.ignore_hosts 'codeclimate.com'
 end


### PR DESCRIPTION
the previous solution does not handle header matching for vcrs

<!---
@huboard:{"order":0.02100372314453125,"milestone_order":5,"custom_state":""}
-->
