### PR TITLE
Rails 6 adjustments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ before_install:
   - gem install bundler
   - gem update bundler
 rvm:
-  - 2.3.8
-  - 2.4.5
   - 2.5.3
-  - 2.6.1
+  - 2.6.5
+  - 2.7.0
 gemfile:
   - gemfiles/rails_5.0.gemfile
   - gemfiles/rails_5.1.gemfile
   - gemfiles/rails_5.2.gemfile
+  - gemfiles/rails_6.0.gemfile
 env:
   - BOOKINGSYNC_URL=https://www.bookingsync.com
 script: "bundle exec rake spec"

--- a/Appraisals
+++ b/Appraisals
@@ -14,6 +14,6 @@ appraise 'rails-5.2' do
 end
 
 appraise 'rails-6.0' do
-  gem 'rails', '~> 6.0.0'
+  gem 'rails', '~> 6.0'
   gem 'sqlite3', '~> 1.4.1'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # master
 
+* Drop support for Ruby prior to 2.5 (to satisfy Rails 6 requirements)
+* Relax bookingsync-engine requirements
+
 # 3.1.0 - 2019-09-19
 
 * Add support for Rails 6.0

--- a/bookingsync_application.gemspec
+++ b/bookingsync_application.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.3.8'
 
   s.add_dependency 'rails', '>= 5.0'
-  s.add_dependency 'bookingsync-engine', '~> 4.0'
+  s.add_dependency 'bookingsync-engine', '>= 4.0'
   s.add_dependency 'jsonapi-resources', '~> 0.1'
   s.add_dependency 'synced'
   s.add_dependency 'dotenv-rails'

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 6.0.0"
+gem "rails", "~> 6.0"
 gem "sqlite3", "~> 1.4.1"
 
 gemspec path: "../"

--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css


### PR DESCRIPTION
* relaxes engine requirements (most likely there will be a major version bump due to dropped ruby support). It should still work with current release though
* drops ruby < 2.5 support (rails 6 requirements)